### PR TITLE
Add 68 packages and new Optimization & Topology sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,9 @@ The document is divided in the following sections:
 - [Learning Math](#learning-math)
 - [Linear Algebra](#linear-algebra)
 - [Number Theory](#number-theory)
+- [Optimization](#optimization)
 - [Probability and Statistics](#probability-and-statistics)
+- [Topology](#topology)
 - [Others](#others)
 
 ---
@@ -28,9 +30,13 @@ The document is divided in the following sections:
 
 - [abstract_algebra](https://github.com/alreich/abstract_algebra): Abstract Algebra: An implementation of Finite
   Algebras: Groups, Rings, Fields, Vector Spaces, Modules, Monoids, Semigroups, and Magmas
+- [clifford](https://github.com/pygae/clifford): Geometric Algebra (Clifford algebra) for Python
+- [fxpmath](https://github.com/francof2a/fxpmath): A Python library for fractional fixed-point (base 2) arithmetic and binary manipulation
+- [galgebra](https://github.com/pygae/galgebra): Symbolic Geometric Algebra/Calculus package for SymPy
 - [Galois](https://github.com/mhostetter/galois): A performant NumPy extension for Galois fields and their applications
 - [Hypercomplex](https://github.com/discretegames/hypercomplex): A Python library for working with arbitrary-dimension
   hypercomplex numbers following the Cayley-Dickson construction of algebras
+- [jaxga](https://github.com/RobinKa/jaxga): Geometric Algebra package for JAX
 - [pixell](https://github.com/simonsobs/pixell): A rectangular pixel map manipulation and harmonic analysis library derived from Sigurd Naess' enlib
 - [Plabic](https://github.com/Cobord/Plabic): Cluster algebraic/geometric structures related to plabic graphs
 - [PyFinite](https://github.com/emin63/pyfinite): Finite field math in python including generic matrix operations and
@@ -45,6 +51,8 @@ The document is divided in the following sections:
 ## Analysis
 
 - [dedalus](https://github.com/DedalusProject/dedalus): A flexible framework for solving PDEs with modern spectral methods
+- [diffrax](https://github.com/patrick-kidger/diffrax): Numerical differential equation solvers in JAX; autodifferentiable and GPU-capable
+- [dolfinx](https://github.com/FEniCS/dolfinx): Next generation FEniCS problem solving environment for solving PDEs with the finite element method
 - [findiff](https://github.com/maroba/findiff): Python package for numerical derivatives and partial differential equations in any number of dimensions
 - [foof](https://github.com/fooof-tools/fooof): Parameterizing neural power spectra into periodic & aperiodic components
 - [harmonica](https://github.com/fatiando/harmonica): Forward modeling, inversion, and processing gravity and magnetic data
@@ -52,8 +60,11 @@ The document is divided in the following sections:
 - [PyAbel](https://github.com/PyAbel/PyAbel): A python package for Abel and inverse Abel transforms
 - [pykoopman](https://github.com/dynamicslab/pykoopman): A package for computing data-driven approximations to the Koopman operator
 - [py-pde](https://github.com/zwicker-group/py-pde): Python package for solving partial differential equations using finite differences
+- [quadpy](https://github.com/sigma-py/quadpy): Numerical integration (quadrature, cubature) in Python
+- [scikit-fmm](https://github.com/scikit-fmm/scikit-fmm): A Python extension module implementing the fast marching method
 - [sfepy](https://github.com/sfepy/sfepy): SfePy is a software for solving systems of coupled partial differential equations (PDEs) by the finite element method in 1D, 2D and 3D
 - [SHTOOLS](https://github.com/SHTOOLS/SHTOOLS): Spherical Harmonic Tools
+- [torchsde](https://github.com/google-research/torchsde): Differentiable SDE solvers with GPU support and efficient sensitivity analysis
 
 ## Animations and Images
 
@@ -78,8 +89,14 @@ The document is divided in the following sections:
 ## General Mathematics
 
 - [AxiomPy](https://github.com/rkstudio585/AxiomPy): A python library for advance mathematics operations.
+- [diofant](https://github.com/diofant/diofant): A Python computer algebra system (CAS), originally a fork of SymPy
+- [gmpy2](https://github.com/gmpy2/gmpy2): General multiple-precision arithmetic for Python (GMP, MPFR, MPC)
 - [libMath](https://github.com/4pz/libmaths): A Python library created to assist programmers with complex mathematical
   functions
+- [Mathics](https://github.com/Mathics3/mathics-core): A free, general-purpose computer algebra system featuring Wolfram Language compatibility
+- [mpmath](https://github.com/mpmath/mpmath): A Python library for arbitrary-precision floating-point arithmetic
+- [pymbolic](https://github.com/inducer/pymbolic): A simple package to do symbolic math (focus on code generation and DSLs)
+- [Sage](https://github.com/sagemath/sage): SageMath, a free open-source mathematics software system (computer algebra system)
 - [SciPy](https://github.com/scipy/scipy): SciPy (pronounced "Sigh Pie") is an open-source software for mathematics,
   science, and engineering. It includes modules for statistics, optimization, integration, linear algebra, Fourier
   transforms, signal and image processing, ODE solvers, and more
@@ -89,12 +106,27 @@ The document is divided in the following sections:
 ## Geometry
 
 - [boule](https://github.com/fatiando/boule): Reference ellipsoids for geodesy and geophysics
+- [COMPAS](https://github.com/compas-dev/compas): Core library of the COMPAS framework for research in architecture, engineering and digital fabrication
+- [gpytoolbox](https://github.com/sgsellan/gpytoolbox): A collection of utility functions to prototype geometry processing research in Python
+- [meshio](https://github.com/nschloe/meshio): Input/output for many mesh formats
+- [NURBS-Python](https://github.com/orbingol/NURBS-Python): Object-oriented pure Python B-Spline and NURBS library
+- [polytope](https://github.com/tulip-control/polytope): Geometric operations on polytopes of any dimension
+- [pygmsh](https://github.com/nschloe/pygmsh): A high-level abstraction for the mesh generator Gmsh in Python
 - [pymanopt](https://github.com/pymanopt/pymanopt): Python toolbox for optimization on Riemannian manifolds with support for automatic differentiation
+- [pytransform3d](https://github.com/dfki-ric/pytransform3d): 3D transformations for Python
+- [roma](https://github.com/naver/roma): A lightweight library to deal with 3D rotations in PyTorch
+- [shapely](https://github.com/shapely/shapely): Manipulation and analysis of geometric objects in the Cartesian plane
+- [trimesh](https://github.com/mikedh/trimesh): Python library for loading and using triangular meshes
 
 ## Graph Theory
 
 - [graph-theory](https://github.com/root-11/graph-theory): A simple graph library
+- [graphblas-algorithms](https://github.com/python-graphblas/graphblas-algorithms): Graph algorithms written in GraphBLAS
+- [networkit](https://github.com/networkit/networkit): A toolkit for large-scale network analysis
+- [networkx](https://github.com/networkx/networkx): Creation, manipulation, and study of the structure, dynamics and functions of complex networks
 - [PrRGG](https://github.com/sepandhaghighi/pyrgg): Python Random Graph Generator
+- [python-igraph](https://github.com/igraph/python-igraph): Python interface for the igraph high-performance graph library
+- [rustworkx](https://github.com/Qiskit/rustworkx): A high-performance Python graph library implemented in Rust
 
 ## Group Theory
 
@@ -102,10 +134,13 @@ The document is divided in the following sections:
 - [abeliantensors](https://github.com/mhauru/abeliantensors): A library for Abelian symmetry preserving tensors in
   Python 3
 - [bella](https://github.com/aelzenaar/bella): New computational package for small-rank matrix groups
+- [jaxlie](https://github.com/brentyi/jaxlie): Rigid transforms and Lie groups (SO(2), SE(2), SO(3), SE(3)) for JAX
 - [Liegroups](https://github.com/utiasSTARS/liegroups): Python implementation of SO2, SE2, SO3, and SE3 matrix Lie
   groups using numpy or pytorch
+- [liepy](https://github.com/gutfeeling/liepy): Computes representation matrices for Lie groups
 - [Permuta](https://github.com/PermutaTriangle/Permuta): A native Python library for permutation pattern research
 - [Permutation](https://github.com/jwodder/permutation): Permutations of finitely many positive integers
+- [spgrep](https://github.com/spglib/spgrep): On-the-fly generator of space-group irreducible representations
 - [symmetria](https://github.com/VascoSch92/symmetria): Symmetria provides an intuitive, thorough, and comprehensive framework for interacting with the symmetric group and its elements.
 
 ## Learning Math
@@ -118,41 +153,81 @@ The document is divided in the following sections:
 
 ## Linear Algebra
 
+- [block](https://github.com/bamos/block): An intelligent block matrix library for numpy, PyTorch, and beyond
 - [hermite-function](https://github.com/goessl/hermite-function): A Hermite function series module
+- [lineax](https://github.com/patrick-kidger/lineax): Linear solvers in JAX and Equinox
 - [multipoly](https://github.com/goessl/multipoly): A multivariate polynomial module
 - [NumPy](https://github.com/numpy/numpy): The fundamental package for scientific computing with Python
 - [Spatial Maths for Python](https://github.com/bdaiinstitute/spatialmath-python): Create, manipulate and convert
   representations of position and orientation in 2D or 3D using Python
 - [PentaPy](https://github.com/GeoStat-Framework/pentapy): A Python toolbox for pentadiagonal linear systems
+- [pygraphblas](https://github.com/Graphegon/pygraphblas): A Python wrapper around the GraphBLAS API for sparse linear algebra on graphs
 - [PyLops](https://github.com/PyLops/pylops): A Linear-Operator Library for Python
 - [PyParadiso](https://github.com/haasad/PyPardiso): Python interface to the Intel MKL Pardiso library to solve large sparse linear systems of equations.
 - [Poisson-solver-2D](https://github.com/zaman13/Poisson-solver-2D): Finite difference solution of 2D Poisson equation.
   Can handle Dirichlet, Neumann and mixed boundary conditions
+- [scikit-spatial](https://github.com/ajhynes7/scikit-spatial): Spatial objects and computations based on NumPy arrays
+- [vg](https://github.com/lace/vg): Vector-geometry and linear-algebra toolbelt for 3D points and vectors
+- [xitorch](https://github.com/xitorch/xitorch): Differentiable scientific computing library (linear algebra, optimization, integration) for PyTorch
 
 ## Number Theory
 
 - [AlgNuTh](https://github.com/louisabraham/algnuth): Algebraic Number Theory package
+- [continuedfractions](https://github.com/sr-murthy/continuedfractions): Object-oriented continued fractions with Python
+- [Number-Theory-Python](https://github.com/Robert-Campbell-256/Number-Theory-Python): Python code implementing various number theory, elliptic curve and finite field computations
 - [primePy](https://github.com/janaindrajit/primePy): This module cal quickly find prime factors with multiplicity of a
   given number. This module also has several other prime factor functions
 - [primesieve-Python](https://github.com/shlomif/primesieve-python): Fast prime number generator. Python bindings for
   the primesieve C++ library
 - [pyadic](https://github.com/GDeLaurentis/pyadic): p-Adic numbers and finite fields in Python
+- [python-flint](https://github.com/flintlib/python-flint): Python bindings for FLINT (Fast Library for Number Theory) and Arb
 - [sequentium](https://github.com/VascoSch92/sequentium): Sequentium is a user-friendly package that implements various well-known sequences, providing a seamless and intuitive experience for the user
 - [oeis](https://github.com/JulienPalard/oeis): Newcomer friendly project implementing a few oeis.org sequences
 
+## Optimization
+
+- [cvxpy](https://github.com/cvxpy/cvxpy): A Python-embedded modeling language for convex optimization problems
+- [optax](https://github.com/google-deepmind/optax): A gradient processing and optimization library for JAX
+- [pymoo](https://github.com/anyoptimization/pymoo): Multi-objective optimization in Python (NSGA-II, NSGA-III, MOEA/D, and more)
+- [Pyomo](https://github.com/Pyomo/pyomo): An object-oriented algebraic modeling language in Python for structured optimization problems
+- [PySwarms](https://github.com/ljvmiranda921/pyswarms): A research toolkit for particle swarm optimization (PSO) in Python
 
 ## Probability and Statistics
 
+- [Bambi](https://github.com/bambinos/bambi): BAyesian Model-Building Interface (Bambi) in Python
+- [BlackJAX](https://github.com/blackjax-devs/blackjax): A Bayesian inference library designed for ease of use, speed and modularity
+- [dynesty](https://github.com/joshspeagle/dynesty): Dynamic nested sampling package for computing Bayesian posteriors and evidences
+- [GPJax](https://github.com/thomaspinder/GPJax): Gaussian processes in JAX and Equinox
+- [icepool](https://github.com/HighDiceRoller/icepool): Python dice probability package
+- [NumPyro](https://github.com/pyro-ppl/numpyro): Probabilistic programming with NumPy powered by JAX for autograd and JIT compilation
+- [obscure_stats](https://github.com/glevv/obscure_stats): A small collection of lesser-known statistical measures
+- [particles](https://github.com/nchopin/particles): Sequential Monte Carlo in Python
+- [Pingouin](https://github.com/raphaelvallat/pingouin): Statistical package in Python based on Pandas
 - [PyAutoFit](https://github.com/rhayes777/PyAutoFit/tree/main): PyAutoFit: Classy Probabilistic Programming
+- [PyMC](https://github.com/pymc-devs/pymc): Bayesian modeling and probabilistic programming in Python
+- [Pyro](https://github.com/pyro-ppl/pyro): Deep universal probabilistic programming with Python and PyTorch
+- [sbi](https://github.com/sbi-dev/sbi): A Python package for simulation-based inference
 - [Statsmodels](https://github.com/statsmodels/statsmodels/): statistical modeling and econometrics in Python
 - [thejoker](https://github.com/adrn/thejoker): A custom Monte Carlo sampler for the (gravitational) two-body problem
-- [obscure_stats](https://github.com/glevv/obscure_stats): A small collection of lesser-known statistical measures
 - [WagerBrain](https://github.com/sedemmler/WagerBrain): A package containing the essential math required for sports
   betting and gambling
 
+## Topology
+
+- [GUDHI](https://github.com/GUDHI/gudhi-devel): A generic library with a Python interface for topological data analysis and higher-dimensional geometry
+- [kepler-mapper](https://github.com/scikit-tda/kepler-mapper): A flexible Python implementation of the Mapper algorithm for topological data analysis
+- [ripser.py](https://github.com/scikit-tda/ripser.py): A lean persistent homology library for Python
+- [scikit-tda](https://github.com/scikit-tda/scikit-tda): Topological data analysis for Python
+
 ## Others
 
-- [MathTranslate](https://github.com/SUSYUSTC/MathTranslate): Translate scientific papers with math
+- [Axelrod](https://github.com/Axelrod-Python/Axelrod): A research tool for the Iterated Prisoner's Dilemma and other game-theoretic tournaments
+- [combi](https://github.com/cool-RR/combi): Pythonic package for combinatorics
 - [Gzint](https://github.com/pirate/gzint): A python3 library for efficiently storing massive integers (stands for
   gzipped-integer)
+- [MathTranslate](https://github.com/SUSYUSTC/MathTranslate): Translate scientific papers with math
+- [Nashpy](https://github.com/drvinceknight/Nashpy): A Python library for the computation of equilibria of 2-player strategic games
+- [Pint](https://github.com/hgrecco/pint): Operate and manipulate physical quantities (units of measurement) in Python
 - [PySymmPol](https://github.com/thraraujo/pysymmpol): Manipulation of various symmetric polynomials, and Young diagrams
+- [thewalrus](https://github.com/XanaduAI/thewalrus): A library for the calculation of hafnians, Hermite polynomials and Gaussian boson sampling
+- [uncertainties](https://github.com/lmfit/uncertainties): Transparent calculation of uncertainties (error propagation) on the quantities involved


### PR DESCRIPTION
Adds 68 Python math packages found on GitHub that were not yet listed, and introduces two new sections (**Optimization**, **Topology**) with matching table-of-contents links. New entries are inserted in alphabetical position within each section; the `Probability and Statistics` and `Others` sections were re-sorted to keep them tidy (no existing entries changed text).

### Additions by section

- **Algebra** (4): clifford, fxpmath, galgebra, jaxga
- **Analysis** (5): diffrax, dolfinx, quadpy, scikit-fmm, torchsde
- **General Mathematics** (6): Sage, Mathics, mpmath, gmpy2, diofant, pymbolic
- **Geometry** (10): shapely, trimesh, NURBS-Python, meshio, pygmsh, COMPAS, gpytoolbox, polytope, pytransform3d, roma
- **Graph Theory** (5): networkx, rustworkx, python-igraph, networkit, graphblas-algorithms
- **Group Theory** (3): jaxlie, spgrep, liepy
- **Linear Algebra** (6): lineax, pygraphblas, block, xitorch, vg, scikit-spatial
- **Number Theory** (3): python-flint, Number-Theory-Python, continuedfractions
- **Optimization** *(new section)* (5): cvxpy, Pyomo, pymoo, optax, PySwarms
- **Probability and Statistics** (11): PyMC, Pyro, NumPyro, Pingouin, Bambi, BlackJAX, sbi, GPJax, particles, dynesty, icepool
- **Topology** *(new section)* (4): GUDHI, scikit-tda, ripser.py, kepler-mapper
- **Others** (6): Pint, uncertainties, Nashpy, Axelrod, thewalrus, combi